### PR TITLE
Price style

### DIFF
--- a/growth_stock_screener/screen/iterations/relative_strength.py
+++ b/growth_stock_screener/screen/iterations/relative_strength.py
@@ -40,7 +40,7 @@ if platform.system() == "Darwin":
     price_df = yf_download_batches(1000, symbol_list, timeout)
 else:
     tickers = yf.download(symbol_list, period="2y", timeout=timeout)
-    price_df = tickers["Adj Close"]
+    price_df = tickers["Close"]
 
 # populate these lists while iterating through symbols
 successful_symbols = []

--- a/growth_stock_screener/screen/iterations/utils/scraping.py
+++ b/growth_stock_screener/screen/iterations/utils/scraping.py
@@ -136,6 +136,6 @@ def yf_download_batches(
 
     dfs.append(download_batch(start, end))
 
-    # concatenate the 'Adjusted Price' columns in each DataFrame
-    price_dfs = map(lambda df: df["Adj Close"], dfs)
+    # concatenate the 'Close' columns in each DataFrame
+    price_dfs = map(lambda df: df["Close"], dfs)
     return pd.concat(price_dfs, axis=1)


### PR DESCRIPTION
Since most charting software display price data using close prices which are not adjusted for dividends (only for splits), this pull-request changes downloaded historical price data to 'Close' prices instead of 'Adj Close' prices from Yahoo Finance. This ensures that RS rating calculations are consistent with how stock prices are typically portrayed.